### PR TITLE
Revert "Commit 7c130ee"

### DIFF
--- a/tools/nbictl/connection.go
+++ b/tools/nbictl/connection.go
@@ -64,7 +64,7 @@ func openAPIConnection(appCtx *cli.Context, apiSubDomain string) (*grpc.ClientCo
 
 func adjustURLForAPISubDomain(url string, apiSubDomain string) string {
 	// Unexpectedly empty arguments or already the subdomain sought.
-	if url == "" || apiSubDomain == "" || strings.HasPrefix(url, apiSubDomain) {
+	if url == "" || apiSubDomain == "" || strings.HasPrefix(url, apiSubDomain+".") {
 		return url
 	}
 


### PR DESCRIPTION
This PR reverts commit 7c130ee96e1ac003ce2b22ba51cedab1ca119598, which was accidentally submitted.

Original MR description: 
Only check for the presence of apiSubDomain, i.e. "model", as opposed to apiSubDomain+".", i.e. "model.", when determining whether the URL needs to be modified. This allows URLs such as `model-v1alpha.{domain}` to be unmodified by this logic, which is the desired behavior.