### PR TITLE
Replace fmt.Print TODO with error return in SNMP enactment driver

### DIFF
--- a/agent/internal/agentcli/agentcli.go
+++ b/agent/internal/agentcli/agentcli.go
@@ -426,7 +426,8 @@ enactmentSwitch:
 		nodeOpts = append(nodeOpts, agent.WithEnactmentDriver(node.GetEnactmentDriver().GetConnectionParams().EndpointUri, ed, dialOpts...))
 
 	case *configpb.SdnAgent_EnactmentDriver_Snmp:
-		fmt.Print("TODO: SdnAgent_EnactmentDriver_Snmp")
+		// TODO implement SdnAgent_EnactmentDriver_Snmp
+		return nil, fmt.Errorf("SNMP enactment driver not implemented")
 
 	case *configpb.SdnAgent_EnactmentDriver_Dynamic:
 		dialOpts, err := getDialOpts(ctx, node.EnactmentDriver.GetConnectionParams(), clock)


### PR DESCRIPTION
This PR makes a small cleanup in getNodeOpts. The SNMP enactment driver case was using a raw fmt.Print, which didn’t quite fit with how the rest of the function handles missing or unimplemented options. 

I switched it to return a proper error instead.

The idea here is just to make the behavior a bit clearer and more consistent since the previous version printed a TODO message but didn’t actually signal anything to the caller, so the function would silently fall through. 

Returning an error feels more idiomatic and makes it obvious that this path isn’t implemented yet.
